### PR TITLE
Feature limit tagets

### DIFF
--- a/app/models/user_target.rb
+++ b/app/models/user_target.rb
@@ -3,6 +3,13 @@ class UserTarget < ApplicationRecord
   belongs_to :topic
 
   validates :title, :user, :topic, :latitude, :longitude, :area, presence: true
+  validate :target_limit
 
   DEFAULT_AREAS = [50, 100, 150, 200]
+
+  private
+
+  def target_limit
+    errors.add(:base, 'Too many targets created') if user.user_targets.size > 9
+  end
 end

--- a/spec/controllers/user_targets_controller_spec.rb
+++ b/spec/controllers/user_targets_controller_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe UserTargetsController, type: :controller do
   end
 
   describe 'GET #index' do
-    let!(:target) { FactoryGirl.create(:user_target, user: user, topic: topic, latitude: 0, longitude: 0) }
+    let!(:target) { FactoryGirl.create(:user_target, user: user, topic: topic) }
 
     context 'with user signed in' do
       before(:each) do
@@ -145,10 +145,27 @@ RSpec.describe UserTargetsController, type: :controller do
         end
       end
     end
+
+    context 'when there are too many targets created' do
+      let(:new_target) { target_params('title', 50, topic.id, 0, 0) }
+
+      before(:each) do
+        FactoryGirl.create_list(:user_target,10, user: user, topic: topic)
+        post :create, params: new_target, xhr: true
+      end
+
+      it 'responds HTTP 400' do
+        expect(response).to have_http_status(400)
+      end
+
+      it 'responds with too many targets error' do
+        expect(response.body).to include('Too many targets created')
+      end
+    end
   end
 
   describe '#destroy' do
-    let!(:target) { FactoryGirl.create(:user_target, user: user, topic: topic, latitude: 0, longitude: 0) }
+    let!(:target) { FactoryGirl.create(:user_target, user: user, topic: topic) }
 
     before(:each) do
       sign_in user

--- a/spec/factories/user_target.rb
+++ b/spec/factories/user_target.rb
@@ -2,5 +2,7 @@ FactoryGirl.define do
   factory :user_target, class: 'UserTarget' do
     title 'Art'
     area 100
+    latitude 0
+    longitude 0
   end
 end


### PR DESCRIPTION
This PR includes:
- Limit the number of targets created by the same user

Trello card: https://trello.com/c/acf2xHak/6-2-as-a-user-i-should-only-be-able-to-create-a-maximum-of-10-targets-so-the-map-doesnt-get-too-crowded

![captura de pantalla 2017-09-27 a la s 12 32 37](https://user-images.githubusercontent.com/30729697/30922701-4529fbce-a380-11e7-9bd0-0f98947accb0.png)
